### PR TITLE
Updating build and task setConfig to use assign instead of merge.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "@microsoft/gulp-core-build",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "dependencies": {
     "@microsoft/gulp-core-build": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "from": "@microsoft/gulp-core-build@>=0.9.1 <0.10.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-0.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-0.9.3.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
       "version": "0.3.2",
@@ -23,11 +23,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
         }
       }
-    },
-    "@microsoft/node-library-build": {
-      "version": "0.3.3",
-      "from": "@microsoft/node-library-build@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-0.3.3.tgz"
     },
     "abbrev": {
       "version": "1.0.9",
@@ -144,11 +139,6 @@
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "from": "browser-stdout@1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
-    },
     "buffer-shims": {
       "version": "1.0.0",
       "from": "buffer-shims@>=1.0.0 <2.0.0",
@@ -184,11 +174,6 @@
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
-    "chai": {
-      "version": "3.5.0",
-      "from": "chai@>=3.5.0 <3.6.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
-    },
     "chalk": {
       "version": "1.1.3",
       "from": "chalk@>=1.0.0 <2.0.0",
@@ -205,9 +190,9 @@
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
     },
     "cli-usage": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "from": "cli-usage@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz"
     },
     "cliui": {
       "version": "3.2.0",
@@ -235,9 +220,9 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
     "commander": {
-      "version": "2.9.0",
-      "from": "commander@2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "version": "2.3.0",
+      "from": "commander@2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -505,9 +490,9 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
     },
     "for-in": {
-      "version": "0.1.5",
+      "version": "0.1.6",
       "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
     },
     "for-own": {
       "version": "0.1.4",
@@ -643,11 +628,6 @@
       "from": "graceful-fs@>=4.1.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-    },
     "growl": {
       "version": "1.9.2",
       "from": "growl@1.9.2",
@@ -710,39 +690,7 @@
     "gulp-mocha": {
       "version": "2.2.0",
       "from": "gulp-mocha@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "from": "commander@2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-        },
-        "glob": {
-          "version": "3.2.11",
-          "from": "glob@3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
-        },
-        "mocha": {
-          "version": "2.5.3",
-          "from": "mocha@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz"
-        },
-        "supports-color": {
-          "version": "1.2.0",
-          "from": "supports-color@1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz"
     },
     "gulp-plumber": {
       "version": "1.1.0",
@@ -798,15 +746,20 @@
           "from": "glob@>=5.0.3 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
+        "glob-parent": {
+          "version": "3.0.0",
+          "from": "glob-parent@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz"
+        },
         "glob-stream": {
-          "version": "5.3.4",
+          "version": "5.3.5",
           "from": "glob-stream@>=5.3.2 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
               "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "readable-stream": {
               "version": "1.0.34",
@@ -819,6 +772,16 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
             }
           }
+        },
+        "is-extglob": {
+          "version": "2.0.0",
+          "from": "is-extglob@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz"
+        },
+        "is-glob": {
+          "version": "3.0.0",
+          "from": "is-glob@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz"
         },
         "isarray": {
           "version": "1.0.0",
@@ -917,9 +880,9 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
     },
     "inherits": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
@@ -1195,11 +1158,6 @@
       "from": "json-stable-stringify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
-    "json3": {
-      "version": "3.3.2",
-      "from": "json3@3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-    },
     "jsonfile": {
       "version": "2.3.1",
       "from": "jsonfile@>=2.1.0 <3.0.0",
@@ -1283,19 +1241,14 @@
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._baseclone": {
-      "version": "4.5.7",
-      "from": "lodash._baseclone@>=4.5.0 <4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz"
+      "version": "3.3.0",
+      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "lodash._basecopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
     },
     "lodash._basefor": {
       "version": "3.0.3",
@@ -1365,19 +1318,7 @@
     "lodash.clonedeep": {
       "version": "3.0.2",
       "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "dependencies": {
-        "lodash._baseclone": {
-          "version": "3.3.0",
-          "from": "lodash._baseclone@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
-        }
-      }
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "from": "lodash.create@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.escape": {
       "version": "3.2.0",
@@ -1432,7 +1373,14 @@
     "lodash.merge": {
       "version": "4.3.5",
       "from": "lodash.merge@>=4.3.2 <4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.3.5.tgz",
+      "dependencies": {
+        "lodash._baseclone": {
+          "version": "4.5.7",
+          "from": "lodash._baseclone@>=4.5.0 <4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz"
+        }
+      }
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -1554,19 +1502,29 @@
       }
     },
     "mocha": {
-      "version": "3.0.2",
-      "from": "mocha@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.0.2.tgz",
+      "version": "2.5.3",
+      "from": "mocha@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "escape-string-regexp@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
         "glob": {
-          "version": "7.0.5",
-          "from": "glob@7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+          "version": "3.2.11",
+          "from": "glob@3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "version": "1.2.0",
+          "from": "supports-color@1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
     },
@@ -1586,9 +1544,9 @@
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
     },
     "node-emoji": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "from": "node-emoji@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.1.tgz"
     },
     "node-notifier": {
       "version": "4.5.0",
@@ -1629,7 +1587,7 @@
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.0.1 <5.0.0",
+      "from": "object-assign@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-keys": {
@@ -1742,9 +1700,9 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
     },
     "path-root": {
       "version": "0.1.1",
@@ -1917,9 +1875,9 @@
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
     },
     "source-map": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "gulp": "~3.9.1",
     "gulp-flatten": "~0.2.0",
     "gulp-util": "~3.0.7",
-    "lodash.merge": "~4.3.2",
     "merge2": "~1.0.2",
     "node-notifier": "~4.5.0",
+    "object-assign": "~4.1.0",
     "pretty-hrtime": "~1.0.2",
     "through2": "~2.0.1",
     "yargs": "~4.6.0"

--- a/src/GulpTask.ts
+++ b/src/GulpTask.ts
@@ -7,6 +7,7 @@ import { log, verbose, error, fileError, fileWarning,
 import gutil = require('gulp-util');
 import gulp = require('gulp');
 import through2 = require('through2');
+
 /* tslint:disable:typedef */
 const eos = require('end-of-stream');
 /* tslint:enable:typedef */
@@ -19,10 +20,10 @@ export abstract class GulpTask<TASK_CONFIG> implements IExecutable {
 
   public setConfig(taskConfig: TASK_CONFIG): void {
     /* tslint:disable:typedef */
-    let merge = require('lodash.merge');
+    const objectAssign = require('object-assign');
     /* tslint:enable:typedef */
 
-    this.taskConfig = merge({}, this.taskConfig, taskConfig);
+    this.taskConfig = objectAssign({}, this.taskConfig, taskConfig);
   }
 
   public replaceConfig(taskConfig: TASK_CONFIG): void {

--- a/src/GulpTask.ts
+++ b/src/GulpTask.ts
@@ -23,7 +23,7 @@ export abstract class GulpTask<TASK_CONFIG> implements IExecutable {
     const objectAssign = require('object-assign');
     /* tslint:enable:typedef */
 
-    this.taskConfig = objectAssign({}, this.taskConfig, taskConfig);
+    objectAssign(this.taskConfig, taskConfig);
   }
 
   public replaceConfig(taskConfig: TASK_CONFIG): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,10 +57,10 @@ let _buildConfig: IBuildConfig = {
  */
 export function setConfig(config: IBuildConfig): void {
   /* tslint:disable:typedef */
-  const merge = require('lodash.merge');
+  const objectAssign = require('object-assign');
   /* tslint:enable:typedef */
 
-  _buildConfig = merge({}, _buildConfig, config);
+  _buildConfig = objectAssign({}, _buildConfig, config);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export function setConfig(config: IBuildConfig): void {
   const objectAssign = require('object-assign');
   /* tslint:enable:typedef */
 
-  _buildConfig = objectAssign({}, _buildConfig, config);
+  objectAssign(_buildConfig, config);
 }
 
 /**


### PR DESCRIPTION
This means that we preserve original objects passed into setConfig, rather than creating copies of them, which causes unexpected issues:

Example:

```typescript
const ts = require('typescript');

typescript.setConfig({ typescript: ts });
```
